### PR TITLE
update plugin to webpack 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+  - "6"
   - "5"
   - "4"
-  - "0.12"
 script: npm test
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "6"
-  - "5"
   - "4"
 script: npm test
 branches:
@@ -15,4 +14,4 @@ deploy:
     secure: HNzFs/yaYVti8gTG5JzKpC0y+DnRXEQC/lS48Nncls3wNO2X5WPBWaz/aQgk0cJfNm0UeeoCBTSL9DRvoQOG0143uMI4frm9mXoWlJNlC2w6e6MMbYvHQ7pP8VB9pJGEv4x0xiFVeHyiXnamW2ND9zndziCg3HTbQh/N3e9CVxd5y+JTyD1qxEaZG7SxUMmntNOJNbqv7Gt+KDaXOfPQjDvbjPuTZxIk0Shgud9lbb4FQh1ggSUb6heciV20s37Xh5APA/Blko1reZxRTLHIIE6oTthb0xOryHU6CHomEXX+F68qLABzZGzRRCsJ6obio42Sq5bR7J8/e+MbG0sxIAqGS3BpUK44GLlxzE+BuhESy6VFET4NINKVwjGYDpdgBoNmDDJdPNHckroRqqKuUHaIOO+ITYM+hRtXSMqv0aY8guSYyeHq6RVyFdxMGAjZoLCw+Oy2+H1GWZjsoHBLWhBRQJLZ0lLjQxDFdciiZ64VoZkLtNj6h8u0Bcp2sY8ApLWUZmQzL36Z2UVyrYgyIYNQm5kz2LZX0b6iIh2sVlY5GvZFszMMgxu2CtHJpIoKYadb9qDLjB8PM/MikVmhLNXjDirqO6QzjI+Px5BDxWBGlyC/iXdX0ZqCexnTjpP1/oxBfTgV4fZBx2qxfBKtBTV3f+fPnd4cv/DNZVMrjFI=
   on:
     tags: true
-    node: 5
+    node: 6

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ function InertEntryPlugin() {}
 InertEntryPlugin.prototype.apply = function(compiler) {
 	// placeholder chunk name, to be removed from assets when Webpack emits them
 	var placeholder = '__INERT_ENTRY_CHUNK_' + String(Math.random()).slice(2) + '__';
+	var originalName;
 
 	compiler.plugin('compilation', function(compilation, params) {
 		// don't interfere with child compilers (i.e. used in entry-loader), since:
@@ -23,8 +24,11 @@ InertEntryPlugin.prototype.apply = function(compiler) {
 		}
 
 		// replace the entry chunk output option with the placeholder
-		var originalName = compilation.options.output.filename;
-		compilation.options.output.filename = placeholder;
+		// don't do this if the filename is already changed (i.e. on a subsequent watch build)
+		if (!originalName || compilation.options.output.filename !== placeholder) {
+			originalName = compilation.options.output.filename;
+			compilation.options.output.filename = placeholder;
+		}
 
 		var entries = typeof compilation.options.entry === 'object' ?
 			compilation.options.entry :

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ InertEntryPlugin.prototype.apply = function(compiler) {
 			compilation.options.entry :
 			{ main: compilation.options.entry };
 
-		params.normalModuleFactory.plugin("after-resolve", (data, done) => {
+		params.normalModuleFactory.plugin('after-resolve', (data, done) => {
 			// match the raw request to one of the entry files
 			var name = _.findKey(entries, _.matches(data.rawRequest));
 			if (name) {

--- a/index.js
+++ b/index.js
@@ -30,22 +30,19 @@ InertEntryPlugin.prototype.apply = function(compiler) {
 			compilation.options.entry :
 			{ main: compilation.options.entry };
 
-		params.normalModuleFactory.plugin('after-resolve', (data, done) => {
+		params.normalModuleFactory.plugin('after-resolve', function(data, callback) {
 			// match the raw request to one of the entry files
 			var name = _.findKey(entries, _.matches(data.rawRequest));
 			if (name) {
 				// interpolate `[chunkname]` ahead-of-time, so entry chunk names are used correctly
 				var interpolatedName = originalName.replace(/\[chunkname\]/g, name);
 				// prepend file-loader to the file's loaders, to create the output file
-				var fileLoaderObject = {
+				data.loaders.unshift({
 					loader: fileLoaderPath,
-					options: {
-						'name': interpolatedName
-					}
-				}
-				data.loaders.unshift(fileLoaderObject);
+					options: { name: interpolatedName }
+				});
 			}
-			done(null, data);
+			callback(null, data);
 		});
 	});
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lodash": "^4.6.1"
   },
   "peerDependencies": {
-    "webpack": ">=1.3.0"
+    "webpack": ">=2.2.0"
   },
   "devDependencies": {
     "ava": "^0.18.1",

--- a/package.json
+++ b/package.json
@@ -20,18 +20,18 @@
   },
   "homepage": "https://github.com/erikdesjardins/inert-entry-webpack-plugin#readme",
   "dependencies": {
-    "file-loader": "^0.8.5",
+    "file-loader": "^0.10.0",
     "lodash": "^4.6.1"
   },
   "peerDependencies": {
     "webpack": ">=1.3.0"
   },
   "devDependencies": {
-    "ava": "^0.12.0",
-    "extricate-loader": "0.0.1",
+    "ava": "^0.18.1",
+    "extricate-loader": "0.0.2",
     "html-loader": "^0.4.3",
     "rimraf": "^2.5.2",
-    "spawn-loader": "0.0.1",
-    "webpack": "^1.12.14"
+    "spawn-loader": "0.1.0",
+    "webpack": "^2.2.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -24,8 +24,8 @@ test('single entry chunk', async t => {
 			},
 			module: {
 				loaders: [
-					{ test: /\.html$/, loaders: ['extricate', 'html?attrs=img:src script:src'] },
-					{ test: /\.js$/, loader: 'spawn?name=[name]-dist.js' }
+					{ test: /\.html$/, loaders: ['extricate-loader', 'html-loader?attrs=img:src script:src'] },
+					{ test: /\.js$/, loader: 'spawn-loader?name=[name]-dist.js' }
 				]
 			},
 			plugins: [
@@ -62,9 +62,9 @@ test('multiple entry chunks', async t => {
 			},
 			module: {
 				loaders: [
-					{ test: /\.html$/, loaders: ['extricate', 'html?attrs=img:src script:src'] },
-					{ test: /\.jpg$/, loader: 'file?name=[name]-dist.[ext]' },
-					{ test: /\.js$/, loader: 'spawn?name=[name]-dist.js' }
+					{ test: /\.html$/, loaders: ['extricate-loader', 'html-loader?attrs=img:src script:src'] },
+					{ test: /\.jpg$/, loader: 'file-loader?name=[name]-dist.[ext]' },
+					{ test: /\.js$/, loader: 'spawn-loader?name=[name]-dist.js' }
 				]
 			},
 			plugins: [
@@ -86,7 +86,7 @@ test('multiple entry chunks', async t => {
 	t.regex(twoDistHtml, /^<!DOCTYPE html>/, 'no prelude');
 	t.regex(twoDistHtml, /<img src="hi-dist\.jpg"\/>/, 'references hi-dist.jpg');
 
-	t.ok(hiDistJpg, 'non-empty');
+	t.truthy(hiDistJpg, 'non-empty');
 
 	t.regex(appDistJs, /\bfunction __webpack_require__\b/, 'has prelude');
 	t.regex(appDistJs, /module\.exports = 'this should not be imported';/, 'has exports');
@@ -105,8 +105,8 @@ test('substituting [name] instead of [chunkname]', async t => {
 			},
 			module: {
 				loaders: [
-					{ test: /\.html$/, loaders: ['extricate', 'html'] },
-					{ test: /\.jpg$/, loader: 'file?name=[name]-dist.[ext]' }
+					{ test: /\.html$/, loaders: ['extricate-loader', 'html-loader'] },
+					{ test: /\.jpg$/, loader: 'file-loader?name=[name]-dist.[ext]' }
 				]
 			},
 			plugins: [


### PR DESCRIPTION
- update dependencies versions
- update test to change t.ok to t.truthy (deprecated in ava 0.14)
- remove node.js 0.12 from travis-ci builds (to due ava triggering a syntax error because of es6)
- add node.js 6 to travis-ci builds
closes #10