### PR TITLE
Add support for entry functions.

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,9 +29,9 @@ InertEntryPlugin.prototype.apply = function(compiler) {
 			compilation.options.output.filename = placeholder;
 		}
 
-		var entries = typeof compilation.options.entry === 'object' ?
-			compilation.options.entry :
-			{ main: compilation.options.entry };
+		var entries = compilation.options.entry;
+		if(typeof entries === 'function') entries = entries();
+		if(typeof entries !== 'object') entries = { main: entries };
 
 		params.normalModuleFactory.plugin('after-resolve', function(data, callback) {
 			// match the raw request to one of the entry files

--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ InertEntryPlugin.prototype.apply = function(compiler) {
 		}
 
 		var entries = compilation.options.entry;
-		if(typeof entries === 'function') entries = entries();
-		if(typeof entries !== 'object') entries = { main: entries };
+		if (typeof entries === 'function') entries = entries();
+		if (typeof entries !== 'object') entries = { main: entries };
 
 		params.normalModuleFactory.plugin('after-resolve', function(data, callback) {
 			// match the raw request to one of the entry files


### PR DESCRIPTION
This PR adds support for `entry` `functions`. Currently, only `string`, `[string]`, and `object` are supported, yet the [webpack documentation](https://webpack.js.org/configuration/entry-context/) specifies `functions` are accepted too.